### PR TITLE
vcluster k8s version set

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -109,7 +109,7 @@ Config.params['clusters'].each do |cluster_entry|
       next
     end
 
-    sh "vcluster create #{cluster}"
+    sh "vcluster create #{cluster} --set vcluster.image=rancher/k3s:v#{Config.params['k8s_version']}-k3s1"
     sh "vcluster disconnect"
   end
 


### PR DESCRIPTION
Change: 
control exactly the k8s version of virtual clusters (vclusters).

Description:
When defining `k8s_version` variable at config.yaml, it was only used to define it for the k3d cluster (the base cluster), but not for vclusters, where tsb actually runs. The vcluster version was the default one `v1.25.14` of vcluster `vcluster version 0.16.3`.

